### PR TITLE
add new mappings

### DIFF
--- a/src/BrowserNameMapper.php
+++ b/src/BrowserNameMapper.php
@@ -40,7 +40,7 @@ final class BrowserNameMapper
             'mobile safari', 'mobile safari/wkwebview', 'safari mobile', 'webview', 'mobile safari uiwebview' => 'Safari',
             'chrome mobile ios', 'chrome frame', 'chrome for ios', 'crios', 'chrome mobile', 'mobile chrome' => 'Chrome',
             'android', 'android browser', 'aliyun browser' => 'Android Webkit',
-            'googlebot', 'google bot mobile', 'adsbot google-mobile', 'adsbot google', 'google web preview', 'google publisher wordpress plugin', 'google web snippet', 'google ads conversions', 'google ads qualify', 'google adwords displayads webrender', 'google-inspectiontool', 'google feedfetcher', 'adsense bot', 'google adwords instant', 'google image search', 'google sites', 'google app engine', 'google adwords express', 'google adstxt', 'google shopping quality', 'google adwords displayads', 'google stale content probe' => 'Google Bot',
+            'googlebot', 'google bot mobile', 'adsbot google-mobile', 'adsbot google', 'google web preview', 'google publisher wordpress plugin', 'google web snippet', 'google ads conversions', 'google ads qualify', 'google adwords displayads webrender', 'google-inspectiontool', 'google feedfetcher', 'adsense bot', 'google adwords instant', 'google image search', 'google sites', 'google app engine', 'google adwords express', 'google adstxt', 'google shopping quality', 'google adwords displayads', 'google stale content probe', 'google other' => 'Google Bot',
             'bingbot', 'bing preview', 'bingpreview', 'adidxbot', 'msnbot-media' => 'BingBot',
             'jakarta commons-httpclient' => 'Jakarta Commons HttpClient',
             'adsbot-google' => 'AdsBot Google',
@@ -368,6 +368,7 @@ final class BrowserNameMapper
             'wesee:search', 'wesee:ads' => 'WeSEE:Search',
             'icatcher', 'icatcher podcast player' => 'iCatcher',
             'yandex news links', 'yandexnewslinks' => 'Yandex News Links',
+            'claude-user', 'claude code' => 'Claude-User',
             default => $browserInput,
         };
     }

--- a/src/DeviceMarketingnameMapper.php
+++ b/src/DeviceMarketingnameMapper.php
@@ -95,7 +95,7 @@ final class DeviceMarketingnameMapper
             'galaxy a06', 'galaxy a06 (international)' => 'Galaxy A06',
             'galaxy a7', 'galaxy a7 lte duos', 'galaxy a7 duos' => 'Galaxy A7',
             'galaxy a7 (2016)', 'galaxy a7 (europe, south africa, kazakhstan, russia, 2016)', 'galaxy a7 (hong kong, china, 2016)' => 'Galaxy A7 (2016)',
-            'galaxy a11', 'galaxy a11 (inernational)', 'galaxy a11 (usa)' => 'Galaxy A11',
+            'galaxy a11', 'galaxy a11 (international)', 'galaxy a11 (usa)' => 'Galaxy A11',
             'galaxy a12', 'galaxy a12 (india)', 'galaxy a12 (usa)', 'galaxy a12 nacho' => 'Galaxy A12',
             'galaxy a13', 'galaxy a13 (usa)', 'galaxy a13 (usa unlocked)', 'galaxy a13 (korea)' => 'Galaxy A13',
             'galaxy a13 5g', 'galaxy a13 5g (international)', 'galaxy a13 5g (usa unlocked)' => 'Galaxy A13 5G',

--- a/src/DeviceMarketingnameMapper.php
+++ b/src/DeviceMarketingnameMapper.php
@@ -95,7 +95,7 @@ final class DeviceMarketingnameMapper
             'galaxy a06', 'galaxy a06 (international)' => 'Galaxy A06',
             'galaxy a7', 'galaxy a7 lte duos', 'galaxy a7 duos' => 'Galaxy A7',
             'galaxy a7 (2016)', 'galaxy a7 (europe, south africa, kazakhstan, russia, 2016)', 'galaxy a7 (hong kong, china, 2016)' => 'Galaxy A7 (2016)',
-            'galaxy a11', 'galaxy a11 (inernational)' => 'Galaxy A11',
+            'galaxy a11', 'galaxy a11 (inernational)', 'galaxy a11 (usa)' => 'Galaxy A11',
             'galaxy a12', 'galaxy a12 (india)', 'galaxy a12 (usa)', 'galaxy a12 nacho' => 'Galaxy A12',
             'galaxy a13', 'galaxy a13 (usa)', 'galaxy a13 (usa unlocked)', 'galaxy a13 (korea)' => 'Galaxy A13',
             'galaxy a13 5g', 'galaxy a13 5g (international)', 'galaxy a13 5g (usa unlocked)' => 'Galaxy A13 5G',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Fehlerbehebungen
* Zusätzliche Variante des Galaxy A11 Gerätenamens normalisiert, um konsistente Gerätenamen-Zuordnungen zu gewährleisten.
* Google-Bot-Erkennung erweitert, um weitere UAwortvariante korrekt als "Google Bot" zuzuordnen.
* Neue Normalisierungen für "claude-user" und "claude code" hinzugefügt, beide werden nun konsistent als "Claude-User" ausgegeben.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->